### PR TITLE
Add props.class attributes

### DIFF
--- a/src/tree-node.svelte
+++ b/src/tree-node.svelte
@@ -45,7 +45,7 @@
     {#if node.children}
       <div class="button" class:active={showChildren}>
         <svg focusable="false" viewBox="0 0 24 24">
-          <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z" />
+          <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z" class={$$props.class} />
         </svg>
       </div>
     {:else}
@@ -56,7 +56,7 @@
   {#if node.children && showChildren}
     <div class="children" transition:slide|local>
       {#each node.children as _node, i}
-        <svelte:self node={_node} index={i} let:node>
+        <svelte:self node={_node} index={i} let:node  class={$$props.class}>
           <slot {node} />
         </svelte:self>
       {/each}

--- a/src/tree.svelte
+++ b/src/tree.svelte
@@ -4,7 +4,7 @@
 </script>
 
 {#each tree as _node, i}
-  <TreeNode node={_node} index={i} let:node>
+  <TreeNode node={_node} index={i} let:node class={$$props.class}>
     <slot {node}>
       <div class="name">{node.name}</div>
     </slot>


### PR DESCRIPTION
This allows the svg paths that draw the arrows to be styled. Here's an example of responding to global CSS (dark-mode) class changes

```
    <div class="parent">
    <Tree class="treeClass" tree={structureTree} let:node>
        {#if node.children}
            <div class="tree-node">{node.name}</div>
        {:else}
            <div class="label-node"><AbilityBug ability={getAbilityBySkill(node.id)}></AbilityBug></div>
        {/if}
    </Tree>
    </div>

<style>
    .tree-node {
        line-height: 1.8;
    }
    :global(body.dark-mode) .parent :global(.treeClass) {
        fill: #bfc2c7;
    }
</style>

```